### PR TITLE
added suffix (not prefix) to vocab term name - for FOAF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
   extremely slow (e.g. 2025-07-23 with w3id.org, or FOAF occasionally!).
 - Use correct cached filename when reading locally cached vocabs with multiple
   inputs.
+- Add 'name' as a vocab term that requires suffixing (with an underscore), as
+  FOAF.name causes a TypeScript name clash when defined as a member of a Class
+  in generated code.
 
 ## 4.0.0 2024-03-12
 

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -200,7 +200,7 @@ module.exports = class DatasetHandler {
     // the actual IRI. (We also have to 'replaceAll' for examples like VCARD's
     // term 'http://www.w3.org/2006/vcard/ns#post-office-box'!).
     //  We also need to handle leading characters that are digits (e.g., the
-    //  Auto Core vocab here:
+    // Auto Core vocab here:
     //    https://spec.edmcouncil.org/auto/ontology/VC/VehicleCore/
     //  ...has terms like '0to100KMH' and '0to60MPH').
     // The FAIR vocabulary uses dots/full-stops '.' to name some of its
@@ -210,8 +210,9 @@ module.exports = class DatasetHandler {
     const firstCharacter = name.charAt(0);
     const nameEscapedForLanguage = (
       firstCharacter >= "0" && firstCharacter <= "9" ? `_${name}` : name
-    ).replace(/[-\/.]/g, "_");
-    // const nameEscapedForLanguage = name.replace(/[-\/]/g, "_");
+    )
+      .replace(/[-\/.]/g, "_")
+      .replace(/^name$/, "name_"); // From the FOAF vocab (when generated as a static member of a TypeScript vocab Class).
 
     // TODO: Currently these alterations are required only for Java-specific
     //  keywords (i.e. VCard defines a term 'class', and DCTERMS defines the


### PR DESCRIPTION
# New feature description

Support the generation of the FOAF vocab as a TypeScript class by suffixing any term named 'name'.

# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).