### PR TITLE
included length in keywords to be suffixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 - Add 'name' as a vocab term that requires suffixing (with an underscore), as
   FOAF.name causes a TypeScript name clash when defined as a member of a Class
   in generated code.
+- Add 'length' as a vocab term that requires suffixing (it's a method in
+  TypeScript 'Function').
 
 ## 4.0.0 2024-03-12
 

--- a/src/DatasetHandler.js
+++ b/src/DatasetHandler.js
@@ -212,7 +212,8 @@ module.exports = class DatasetHandler {
       firstCharacter >= "0" && firstCharacter <= "9" ? `_${name}` : name
     )
       .replace(/[-\/.]/g, "_")
-      .replace(/^name$/, "name_"); // From the FOAF vocab (when generated as a static member of a TypeScript vocab Class).
+      .replace(/^name$/, "name_") // From the FOAF vocab (when generated as a static member of a TypeScript vocab Class).
+      .replace(/^length$/, "length_"); // Error in TypeScript - it's a static member of a TypeScript 'Function').
 
     // TODO: Currently these alterations are required only for Java-specific
     //  keywords (i.e. VCard defines a term 'class', and DCTERMS defines the


### PR DESCRIPTION
# New feature description

Add keyword 'length' to list of terms to be suffixed (causes an error in generated TypeScript vocab Class).
# Checklist

- [X] All acceptance criteria are met.
- [X] Relevant documentation, if any, has been written/updated.
- [X] The changelog has been updated, if applicable.
- [X] New functions/types have been exported in `index.ts`, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).